### PR TITLE
feat: add trait derives to public types

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 
-use crate::{sys, DeviceGroup, Seat};
+use crate::{macros, sys, DeviceGroup, Seat};
 
 /// A base handle for accessing libinput devices.
 pub struct Device {
@@ -164,3 +164,5 @@ impl Clone for Device {
         }
     }
 }
+
+macros::impl_debug!(Device, DeviceCapability);

--- a/src/device_group.rs
+++ b/src/device_group.rs
@@ -1,4 +1,4 @@
-use crate::sys;
+use crate::{macros, sys};
 
 /// A base handle for accessing libinput device groups.
 pub struct DeviceGroup {
@@ -31,3 +31,5 @@ impl Clone for DeviceGroup {
         }
     }
 }
+
+macros::impl_debug!(DeviceGroup);

--- a/src/event.rs
+++ b/src/event.rs
@@ -71,12 +71,7 @@ macro_rules! define_events {
                     raw: *mut $raw,
                 }
 
-
-                impl std::fmt::Debug for [<$main $event Event>] {
-                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        write!(f,stringify!($event))
-                    }
-                }
+                crate::macros::impl_debug!([<$main $event Event>]);
 
                 impl crate::event::sealed::EventSealed for [<$main $event Event>] {}
 

--- a/src/event/keyboard.rs
+++ b/src/event/keyboard.rs
@@ -51,6 +51,7 @@ impl KeyboardKeyEvent {
 }
 
 /// Logical state of a key. Note that the logical state may not represent the physical state of the key.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum KeyState {
     /// Logical released state
     Released,

--- a/src/event_stream.rs
+++ b/src/event_stream.rs
@@ -48,6 +48,7 @@ use crate::{Error, Event, Libinput, Result};
 /// The stream internally manages an [`AsyncFd`] wrapper around the libinput file descriptor,
 /// ensuring efficient integration with tokio's event loop. It will only wake up when new
 /// events are available to be read from the libinput context.
+#[derive(Debug)]
 pub struct EventStream {
     libinput: Libinput,
     fd: AsyncFd<i32>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,3 +267,23 @@ impl Libinput {
         EventStream::new(self.clone(), self.get_fd())
     }
 }
+
+mod macros {
+    /// Implements `std::fmt::Debug` on each provided type,
+    /// writing `Name(<ptr>)` to obfuscate the pointer field.
+    macro_rules! impl_debug {
+        ($($name:ident),+) => {
+            $(
+                impl std::fmt::Debug for $name {
+                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(f, "{}(<ptr>)", stringify!($name))
+                    }
+                }
+            )+
+        }
+    }
+
+    pub(crate) use impl_debug;
+}
+
+macros::impl_debug!(Libinput);

--- a/src/seat.rs
+++ b/src/seat.rs
@@ -1,4 +1,4 @@
-use crate::sys;
+use crate::{macros, sys};
 
 /// The base handle for accessing libinput seats
 pub struct Seat {
@@ -32,3 +32,5 @@ impl Clone for Seat {
         }
     }
 }
+
+macros::impl_debug!(Seat);


### PR DESCRIPTION
According to the rust [fmt documentation](https://doc.rust-lang.org/std/fmt/#fmtdisplay-vs-fmtdebug), all public types should derive `Debug`. This PR derives the trait for all public types which were missing it. Some other traits have also been derived where useful.