### PR TITLE
fix(tracing): some messages logged with extra newline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ impl Libinput {
 
             // Safety guaranted by libinput
             let message = unsafe { CStr::from_ptr(message) }.to_string_lossy();
+            let message = message.trim_ascii_end();
 
             match priority {
                 sys::libinput_log_priority::LIBINPUT_LOG_PRIORITY_INFO => info!("{message}"),


### PR DESCRIPTION
When using the built-in tracing logger, some messages are logged with an extra newline `\n` character, as these are included in the messages returned from the library.

This can create a lot of unnecessary space in the log output. Example below:

```
2025-04-01T21:59:03.704333Z  INFO ironbar::clients::compositor::hyprland: 39: Starting Hyprland event listener
2025-04-01T21:59:03.717112Z  INFO connect: mpd_protocol::connection: 306: connected successfully version="0.24.0"
2025-04-01T21:59:03.717248Z  INFO mpd_utils::persistent_client: 66: Connected to 'localhost:6600'
2025-04-01T21:59:03.727760Z  INFO colpetto: 132: event1  - Power Button: is tagged by udev as: Keyboard

2025-04-01T21:59:03.727929Z  INFO colpetto: 132: event1  - Power Button: device is a keyboard

2025-04-01T21:59:03.729319Z  INFO colpetto: 132: event0  - Power Button: is tagged by udev as: Keyboard

2025-04-01T21:59:03.729598Z  INFO colpetto: 132: event0  - Power Button: device is a keyboard

2025-04-01T21:59:03.732229Z  INFO ironbar::clients::volume: 168: connected to server
2025-04-01T21:59:03.732270Z  INFO colpetto: 132: event3  - USB HID GMMK V2 96: is tagged by udev as: Keyboard

2025-04-01T21:59:03.732438Z  INFO colpetto: 132: event3  - USB HID GMMK V2 96: device is a keyboard

2025-04-01T21:59:03.734434Z  INFO colpetto: 132: event4  - USB HID GMMK V2 96 Mouse: is tagged by udev as: Mouse
```

This PR adds a simple trim to the message to remove the character, which ensures log messages are kept to a line each.