### PR TITLE
feat(build): migrate libinput probe to system-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,8 +64,8 @@ dependencies = [
  "devil",
  "futures-core",
  "paste",
- "pkg-config",
  "rustix",
+ "system-deps",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -71,6 +81,12 @@ checksum = "0618b0597c9eadafba704c07700dbec8933adb144aaa68a177d3668f5b7bf4d4"
 dependencies = [
  "pkg-config",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -99,6 +115,28 @@ name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "lazy_static"
@@ -232,6 +270,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +349,25 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
@@ -364,6 +450,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,3 +588,9 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,22 @@ tracing = { version = "0.1.44", optional = true }
 
 [build-dependencies]
 cc = "1.2.65"
-pkg-config = "0.3.33"
+system-deps = "7.0"
+
+# libinput requirement, gated per version feature. Consumed by `system-deps` at
+# build time and exposed through `cargo metadata`, so the pkg-config module (and
+# the system package providing it) can be discovered without building.
+[package.metadata.system-deps]
+libinput_1_22 = { name = "libinput", version = "1.22", feature = "1_22" }
+libinput_1_23 = { name = "libinput", version = "1.23", feature = "1_23" }
+libinput_1_24 = { name = "libinput", version = "1.24", feature = "1_24" }
+libinput_1_25 = { name = "libinput", version = "1.25", feature = "1_25" }
+libinput_1_26 = { name = "libinput", version = "1.26", feature = "1_26" }
+libinput_1_27 = { name = "libinput", version = "1.27", feature = "1_27" }
+libinput_1_28 = { name = "libinput", version = "1.28", feature = "1_28" }
+libinput_1_29 = { name = "libinput", version = "1.29", feature = "1_29" }
+libinput_1_30 = { name = "libinput", version = "1.30", feature = "1_30" }
+libinput_1_31 = { name = "libinput", version = "1.31", feature = "1_31" }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/build.rs
+++ b/build.rs
@@ -3,28 +3,14 @@ const FEATURES: &[&str] = &[
 ];
 
 fn main() {
-    let enabled_version = FEATURES
-        .iter()
-        .find(|f| std::env::var(format!("CARGO_FEATURE_{}", f.to_uppercase())).is_ok());
-
-    let version = match enabled_version {
-        None => {
-            panic!(
-                "No libinput version selected. You must enable exactly one of these features: {}",
-                FEATURES.join(", ")
-            );
-        }
-        Some(v) => v,
-    };
-
     let enabled_count = FEATURES
         .iter()
         .filter(|f| std::env::var(format!("CARGO_FEATURE_{}", f.to_uppercase())).is_ok())
         .count();
 
-    if enabled_count > 1 {
+    if enabled_count != 1 {
         panic!(
-            "Multiple libinput versions selected. You must enable exactly one of these features: {}",
+            "You must enable exactly one libinput version feature: {}",
             FEATURES.join(", ")
         );
     }
@@ -33,17 +19,10 @@ fn main() {
         return;
     }
 
-    let pkg_version = version.replace('_', ".");
-
-    pkg_config::Config::new()
-        .atleast_version(&pkg_version)
-        .probe("libinput")
-        .unwrap_or_else(|_| {
-            panic!(
-                "Failed to link to libinput version {}. Make sure it's installed on your system.",
-                pkg_version
-            )
-        });
+    // The required libinput version is declared in `[package.metadata.system-deps]`,
+    // gated on the selected version feature. system-deps probes the matching module,
+    // and the same table is exposed via `cargo metadata` for build-less discovery.
+    system_deps::Config::new().probe().unwrap();
 
     println!("cargo:rerun-if-changed=src/logger.c");
 


### PR DESCRIPTION
pkg-config -> system-deps. Enables metadata level discovery of necessary system packages - the goal is for dependents in ci to install system packages easily based on cargo metadata.